### PR TITLE
Set Clerk domain and isSatellite in Astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,8 @@ import vercel from '@astrojs/vercel';
 // https://astro.build/config
 export default defineConfig({
   integrations: [clerk({
+    domain: "somnolab.com.mx",
+    isSatellite: false,
     appearance: { 
         baseTheme: ['simple'],
         signIn: { variables: { colorPrimary: '#60BDC3', colorForeground: '#60BDC3', colorInputForeground: '#3E8CB1' } },


### PR DESCRIPTION
Added domain: "somnolab.com.mx" and isSatellite: false to the Clerk integration in astro.config.mjs.

This configures Clerk to use the specified custom domain and disables satellite mode while leaving the existing appearance settings intact.