### PR TITLE
Simplify Clerk appearance config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,21 +3,24 @@ import { defineConfig } from 'astro/config';
 import clerk from "@clerk/astro";
 import tailwindcss from '@tailwindcss/vite';
 import { esMX } from '@clerk/localizations';
-
 import vercel from '@astrojs/vercel';
 
-// https://astro.build/config
 export default defineConfig({
   integrations: [clerk({
     domain: "somnolab.com.mx",
     isSatellite: false,
-    appearance: { 
-        baseTheme: ['simple'],
-        signIn: { variables: { colorPrimary: '#60BDC3', colorForeground: '#60BDC3', colorInputForeground: '#3E8CB1' } },
+    appearance: {
+      signIn: { 
+        variables: { 
+          colorPrimary: '#60BDC3', 
+          colorForeground: '#60BDC3', 
+          colorInputForeground: '#3E8CB1' 
+        } 
       },
+    },
     signInForceRedirectUrl: "/citas",
-    localization: esMX}
-  )],
+    localization: esMX
+  })],
   vite: {
     plugins: [tailwindcss()]
   },


### PR DESCRIPTION
Tidy up astro.config.mjs Clerk integration: removed the unused baseTheme setting, consolidated the appearance.signIn variables into a cleaner object structure, and cleaned up whitespace/formatting (including removal of an unused comment). signInForceRedirectUrl and localization remain unchanged.

These edits simplify the Clerk appearance config and improve readability.