### PR TITLE
Add 'Herramientas' section and pages

### DIFF
--- a/src/components/NavBarSimple.astro
+++ b/src/components/NavBarSimple.astro
@@ -3,6 +3,7 @@ const navItems = [
     { name: 'Quiénes Somos', href: '/quienes-somos' },
     { name: 'Servicios', href: '/servicios' },
     { name: 'SomnoBlog', href: '/blog' },
+    { name: 'Herramientas', href: '/herramientas' },
     { name: 'Eventos', href: '/eventos' },
     { name: 'Cursos', href: '/cursos' },
 ];

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -4,6 +4,7 @@ const { userId } = Astro.locals.auth();
 const navItems = [
     { name: 'Servicios', href: '/servicios' },
     { name: 'SomnoBlog', href: '/blog' },
+    { name: 'Herramientas', href: '/herramientas' },
     { name: 'Eventos', href: '/eventos' },
     { name: 'Cursos', href: '/cursos' },
     { name: 'Quiénes Somos', href: '/quienes-somos' },

--- a/src/components/NavbarTransparente.astro
+++ b/src/components/NavbarTransparente.astro
@@ -4,6 +4,7 @@ const { userId } = Astro.locals.auth();
 const navItems = [
     { name: 'Servicios', href: '/servicios' },
     { name: 'SomnoBlog', href: '/blog' },
+    { name: 'Herramientas', href: '/herramientas' },
     { name: 'Eventos', href: '/eventos' },
     { name: 'Cursos', href: '/cursos' },
     { name: 'Quiénes Somos', href: '/quienes-somos' },

--- a/src/pages/herramientas.astro
+++ b/src/pages/herramientas.astro
@@ -1,0 +1,79 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Navbar from '../components/Navbar.astro';
+
+const herramientas = [
+    {
+        slug: '/herramientas/habitos-sueno',
+        titulo: 'Hábitos para mejorar mi sueño',
+        descripcion: 'Registra y da seguimiento a tus hábitos de sueño durante cuatro semanas. Imprimible y fácil de usar.',
+        icono: 'fa-moon',
+        etiqueta: 'Plantilla',
+    },
+];
+---
+
+<Layout title="Herramientas | SomnoLab">
+    <Navbar />
+
+    <section class="relative min-h-dvh bg-slate-50 pt-32 pb-24 overflow-x-clip">
+
+        <div class="absolute top-[-5%] right-[-5%] w-96 h-96 bg-somno-light/20 rounded-full blur-[120px] pointer-events-none"></div>
+        <div class="absolute bottom-[-5%] left-[-10%] w-120 h-120 bg-somno/10 rounded-full blur-[100px] pointer-events-none"></div>
+
+        <div class="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+
+            <div class="text-center mb-16 space-y-4 animate-fade-in-up">
+                <span class="inline-block text-somno font-bold tracking-wider uppercase text-sm">
+                    Recursos gratuitos
+                </span>
+                <h1 class="text-5xl sm:text-6xl font-black tracking-tighter text-slate-900 leading-[1.1]">
+                    Herramientas para<br/>
+                    <span class="text-transparent bg-clip-text bg-linear-to-r from-somno-dark via-somno to-somno-light">
+                        mejorar tu sueño
+                    </span>
+                </h1>
+                <p class="text-xl text-slate-600 max-w-2xl mx-auto font-light leading-relaxed">
+                    Recursos diseñados por nuestros especialistas para que puedas trabajar en tu descanso desde casa.
+                </p>
+            </div>
+
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {herramientas.map((h) => (
+                    <a
+                        href={h.slug}
+                        class="group bg-white rounded-3xl border border-slate-100 shadow-sm hover:shadow-md hover:-translate-y-1 transition-all duration-300 p-8 flex flex-col gap-6"
+                    >
+                        <div class="w-14 h-14 rounded-2xl bg-somno/10 flex items-center justify-center text-somno border border-somno/10">
+                            <i class={`fas ${h.icono} text-2xl`}></i>
+                        </div>
+
+                        <div class="flex flex-col gap-2 grow">
+                            <span class="text-[10px] font-bold uppercase tracking-wider text-somno bg-somno/10 px-2.5 py-1 rounded-full w-fit">
+                                {h.etiqueta}
+                            </span>
+                            <h2 class="text-xl font-black text-slate-800 tracking-tight">{h.titulo}</h2>
+                            <p class="text-slate-500 text-sm leading-relaxed font-light">{h.descripcion}</p>
+                        </div>
+
+                        <div class="flex items-center gap-2 text-somno font-bold text-sm group-hover:gap-3 transition-all duration-300">
+                            Ver herramienta
+                            <i class="fas fa-arrow-right text-xs"></i>
+                        </div>
+                    </a>
+                ))}
+            </div>
+
+        </div>
+    </section>
+</Layout>
+
+<style>
+    @keyframes fadeInUp {
+        from { opacity: 0; transform: translateY(30px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+    .animate-fade-in-up {
+        animation: fadeInUp 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+    }
+</style>

--- a/src/pages/herramientas/habitos-sueno.astro
+++ b/src/pages/herramientas/habitos-sueno.astro
@@ -1,0 +1,161 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import ReturnButton from '../../components/ReturnButton.astro';
+---
+
+<Layout title="Hábitos para mejorar mi sueño | SomnoLab" showFooter={false}>
+
+    <div class="no-print fixed left-0 right-0 z-40 bg-slate-50/90 backdrop-blur-sm border-b border-slate-200">
+        <div class="max-w-2xl mx-auto px-4 sm:px-6 py-3 flex items-center justify-center gap-4">
+            <ReturnButton href="/herramientas" />
+
+            <button
+                onclick="window.print()"
+                class="shrink-0 flex items-center gap-2 bg-somno hover:bg-somno-dark transition-colors text-white text-sm font-bold px-5 py-2 rounded-full shadow-sm shadow-somno/20"
+            >
+                <i class="fas fa-print"></i>
+                Imprimir
+            </button>
+        </div>
+    </div>
+
+    <main class="bg-white min-h-screen pt-20 pb-20 px-6 sm:px-10">
+
+        <div class="no-print max-w-2xl mx-auto mb-10 text-center space-y-2">
+            <span class="inline-block text-somno font-bold tracking-wider uppercase text-xs">Plantilla</span>
+            <h1 class="text-4xl font-black tracking-tighter text-slate-900">Hábitos para mejorar mi sueño</h1>
+            <p class="text-slate-500 font-light">
+                Escribe un hábito en cada campo, imprime la hoja y marca un casillero por cada día que lo cumplas.
+            </p>
+        </div>
+
+        <div class="tracker-grid max-w-2xl mx-auto space-y-10">
+
+            {[1, 2, 3].map((_) => (
+                <div class="tracker-block rounded-3xl border-2 border-somno/20 overflow-hidden shadow-sm">
+
+                    <!-- Header del bloque -->
+                    <div class="block-header px-6 py-4 flex items-center justify-between">
+                        <div class="flex items-center gap-3">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5 text-white/80">
+                                <path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z" clip-rule="evenodd" />
+                            </svg>
+                            <span class="text-white font-black tracking-tight text-sm uppercase">
+                                Compromiso de hábitos para mejorar mi sueño
+                            </span>
+                        </div>
+                        <span class="text-white/60 font-black text-xs tracking-tighter">SomnoLab</span>
+                    </div>
+
+                    <div class="px-6 py-5 space-y-5 bg-white">
+
+                        <div class="habit-row space-y-1.5">
+                            <div class="flex items-baseline gap-2">
+                                <span class="text-somno font-bold text-xs uppercase tracking-wider shrink-0">Hábito:</span>
+                                <div class="flex-1 border-b-2 border-slate-200"></div>
+                            </div>
+                            <div class="grid grid-cols-2 gap-4">
+                                <div>
+                                    <p class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1.5">Semana 1</p>
+                                    <div class="flex gap-1.5">
+                                        {Array(7).fill(0).map(() => (
+                                            <div class="checkbox w-6 h-6 rounded border-2 border-somno/40 shrink-0"></div>
+                                        ))}
+                                    </div>
+                                </div>
+                                <div>
+                                    <p class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1.5">Semana 2</p>
+                                    <div class="flex gap-1.5">
+                                        {Array(7).fill(0).map(() => (
+                                            <div class="checkbox w-6 h-6 rounded border-2 border-slate-200 shrink-0"></div>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="border-t border-slate-100"></div>
+
+                        <div class="habit-row space-y-1.5">
+                            <div class="flex items-baseline gap-2">
+                                <span class="text-somno font-bold text-xs uppercase tracking-wider shrink-0">Hábito:</span>
+                                <div class="flex-1 border-b-2 border-slate-200"></div>
+                            </div>
+                            <div class="grid grid-cols-2 gap-4">
+                                <div>
+                                    <p class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1.5">Semana 3</p>
+                                    <div class="flex gap-1.5">
+                                        {Array(7).fill(0).map(() => (
+                                            <div class="checkbox w-6 h-6 rounded border-2 border-slate-200 shrink-0"></div>
+                                        ))}
+                                    </div>
+                                </div>
+                                <div>
+                                    <p class="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1.5">Semana 4</p>
+                                    <div class="flex gap-1.5">
+                                        {Array(7).fill(0).map(() => (
+                                            <div class="checkbox w-6 h-6 rounded border-2 border-slate-200 shrink-0"></div>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            ))}
+
+        </div>
+    </main>
+</Layout>
+
+<style>
+    .block-header {
+        background: linear-gradient(to right, #1a6b8a, #3e8cb1);
+    }
+
+    @media print {
+        .no-print,
+        nav,
+        header,
+        #main-nav,
+        #scroll-to-top {
+            display: none !important;
+        }
+
+        main {
+            padding-top: 0 !important;
+            padding-bottom: 0 !important;
+        }
+
+        @page {
+            size: A4 portrait;
+            margin: 1.2cm 1.5cm;
+        }
+
+        body {
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
+        }
+
+        .tracker-block {
+            page-break-inside: avoid;
+            break-inside: avoid;
+        }
+
+        .tracker-grid {
+            max-width: 100% !important;
+        }
+
+        .block-header {
+            background: linear-gradient(to right, #1a6b8a, #3e8cb1) !important;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
+        }
+
+        .checkbox {
+            border: 2px solid #3e8cb1 !important;
+            background: white !important;
+        }
+    }
+</style>


### PR DESCRIPTION
This pull request introduces a new "Herramientas" (Tools) section to the website, making it accessible from all navigation bars and providing users with a dedicated tools page featuring a printable sleep habits tracker template. The main changes include updates to navigation menus and the addition of new pages for tools and a printable habit tracker.

**Navigation updates:**

* Added a "Herramientas" link to the navigation items in `NavBarSimple.astro`, `Navbar.astro`, and `NavbarTransparente.astro` so users can easily find the new tools section. [[1]](diffhunk://#diff-09239cf9add7d6b5cfb8c19ff6023bb0400e1d6fa47a5bd222bd742aafa1d17aR6) [[2]](diffhunk://#diff-17d65d0f553fedd3c74f4bfceb6be7a20cd69be8066c6014f299cf5c0a4404a7R7) [[3]](diffhunk://#diff-bbaa1b34c23ede89d97ca210991f9990d5527c0cc8efe254328a00ad8b0ef39aR7)

**New tools section:**

* Created a new page at `/herramientas` (`herramientas.astro`) that lists available tools, starting with a sleep habits tracking template. The page includes modern styling and a clear call-to-action.

**New printable resource:**

* Added a dedicated page for the "Hábitos para mejorar mi sueño" template (`herramientas/habitos-sueno.astro`), featuring a printable four-week habit tracker, print-optimized styles, and a button for easy printing.